### PR TITLE
Fix LMS year filter comparison and add regression test

### DIFF
--- a/sess_dev/lms/tests.py
+++ b/sess_dev/lms/tests.py
@@ -1,3 +1,16 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from .views import lmsList
+from .models import lms_details
 
-# Create your tests here.
+class LmsListViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_year_is_all_when_query_zero(self):
+        request = self.factory.get('/lms/', {'q': '0'})
+        request.session = {'emp_id': 1}
+        view = lmsList()
+        view.request = request
+        view.object_list = lms_details.objects.none()
+        context = view.get_context_data()
+        self.assertEqual(context.get('year'), 'All')

--- a/sess_dev/lms/views.py
+++ b/sess_dev/lms/views.py
@@ -39,7 +39,7 @@ class lmsList(LoginRequiredMixin, ListView):
                 print(emp_id)
                 
                 context['lms'] = self.model.objects.filter(emp_id = emp_id).filter(ls_date__icontains = q)
-                if q is '0':
+                if q == '0':
                     context['year'] = 'All'
                     return context
 


### PR DESCRIPTION
## Summary
- fix LMS year filter to use equality comparison
- add regression test for year 'All' selection

## Testing
- `python manage.py test` *(fails: ValueError: Incorrect timezone setting: Asia/Calcutta)*

------
https://chatgpt.com/codex/tasks/task_e_68b47ddaa3108327a6d21b8a47638abe