### PR TITLE
Use Asia/Kolkata timezone

### DIFF
--- a/sess_dev/sess_dev/settings.py
+++ b/sess_dev/sess_dev/settings.py
@@ -113,7 +113,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Asia/Calcutta'
+TIME_ZONE = 'Asia/Kolkata'
 
 USE_I18N = True
 


### PR DESCRIPTION
## Summary
- replace deprecated Asia/Calcutta timezone with Asia/Kolkata

## Testing
- ❌ `python manage.py makemigrations --check --dry-run` (Django 2.0 incompatible with Python 3.11: module 'collections' has no attribute 'Iterator')
- ✅ `python - <<'PY'
import pytz, datetime
print('Current time in Asia/Kolkata:', datetime.datetime.now(pytz.timezone('Asia/Kolkata')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b484ea1e0c83279f6db11bc253b20c